### PR TITLE
Add indent for song buttons

### DIFF
--- a/generateWebPage.py
+++ b/generateWebPage.py
@@ -8,7 +8,7 @@ from importlib import reload
 import utility.misc
 reload(utility.misc)
 
-replaceaao = utility.misc.replaceaao
+replaceaao = utility.misc.replaceaao   #replaceåäö
 fix_youtube_url = utility.misc.fix_youtube_url
 extractNum = utility.misc.extractNum
 
@@ -53,7 +53,7 @@ def getSpexSets(spex):
     string_part_sets += ")"
 
     # ╒══════════════════════════════════════════════════════════════════════════╕
-    # │ RexEx to transform naming convention in 'sparmen/spex' to shorter format │
+    # │ RegEx to transform naming convention in 'sparmen/spex' to shorter format │
     # └──────────────────────────────────────────────────────────────────────────┘
     string_part_sets = re.sub(r"Kivik", "S", string_part_sets)
     string_part_sets = re.sub(r"Karnevalen", "K", string_part_sets)
@@ -174,7 +174,7 @@ def createYearButton(spex, year):
     yearTITLE = re.sub(r"[-]*.txt", "", yearTITLE)
 
     titleBox = '''<div class="sb"
-    style="background-color:#1a1a1a;color:white;text-align:left;font-weight:bold;font-size:20;border-left:2px-solid-red;padding:5px;">{}</div>
+    style="background-color:#1a1a1a;color:white;text-align:left;font-weight:bold;font-size:20;border-left:2px-solid-red;padding:5px;margin-left:0px;">{}</div>
     '''.format(yearTITLE)
 
     return titleBox

--- a/pageTemplate.html
+++ b/pageTemplate.html
@@ -10,6 +10,7 @@
             background-color: black;
         }
 
+        /* song page */
         .sp {
             transition: all 0.4s ease 0s;
             cursor: pointer;
@@ -58,9 +59,10 @@
             color: black;
         }
 
+        /* song button */
         .sb {
             transition: all 0.4s ease 0s;
-            cursor: pointer;
+            cursor: auto;
             padding: 5px 0 0 0;
             width: 100%;
             border: 1px solid #000000 !important;
@@ -68,6 +70,7 @@
             outline: none;
             font-size: 14px;
             border-radius: 10px;
+            margin-left: 15px;
         }
 
         .content {
@@ -80,6 +83,7 @@
             border-bottom: 2px solid green;
             border-bottom-left-radius: 9px;
             border-bottom-right-radius: 9px;
+            cursor: auto;
         }
 
         .song {


### PR DESCRIPTION
Before this commit it was difficult to get an overview due to the year buttons having the same indent margin-left as the song buttons.

<img width="545" alt="beforeafter" src="https://github.com/vargladspexarna/vargladspexarna.github.io/assets/34444482/67563d0a-dd4a-4cc5-99fc-1ec2e304953e">